### PR TITLE
Added dependency checks for fastANI

### DIFF
--- a/scripts/fastani_in_parallel.sh
+++ b/scripts/fastani_in_parallel.sh
@@ -14,6 +14,15 @@
 # more details. You should have received a copy of the GNU General Public License along with
 # Bacsort. If not, see <http://www.gnu.org/licenses/>.
 
+# Check for fastANI
+if command -v fastANI >/dev/null 2>&1 ; then
+    echo "fastANI found"
+    echo "version: $(fastANI -v)"
+else
+    echo "Error: fastANI not found - please install fastANI and try again"
+    exit
+fi
+
 mkdir -p tree
 
 printf "\n"

--- a/scripts/fastani_with_slurm.sh
+++ b/scripts/fastani_with_slurm.sh
@@ -14,6 +14,15 @@
 # more details. You should have received a copy of the GNU General Public License along with
 # Bacsort. If not, see <http://www.gnu.org/licenses/>.
 
+# Check for fastANI
+if command -v fastANI >/dev/null 2>&1 ; then
+    echo "fastANI found"
+    echo "version: $(fastANI -v)"
+else
+    echo "Error: fastANI not found - please install fastANI and try again"
+    exit
+fi
+
 group_count=32
 
 mkdir -p tree


### PR DESCRIPTION
Hi Ryan,

After running fastANI and getting some blank outputs I was confused as the fastANI scripts were suggesting that the job was actually being run. Later I realised I hadn't installed fastANI and that errors caused by fastANI not being found were not being correctly broadcast to the standard out.

I added in a dependency check to both of the looping fastANI scripts. This isn't necessary for the single thread script as the error message is properly shown when fastANI is not installed.

Thanks for putting Bacsort together, it is very helpful.

Cheers,

Max